### PR TITLE
fix: Clicking on the isMuted button is now persisted through stories and page reload.

### DIFF
--- a/packages/stories/src/Components/Video/Video.component.tsx
+++ b/packages/stories/src/Components/Video/Video.component.tsx
@@ -6,12 +6,15 @@ import { SoundIcon } from '../SoundIcon';
 
 const key = 'RSIsMute';
 const WINDOW: any = typeof window === 'undefined' ? {} : window;
-WINDOW?.localStorage?.setItem(key, 'true');
+WINDOW?.localStorage?.setItem(
+  key,
+  WINDOW?.localStorage?.getItem(key) ? WINDOW?.localStorage?.getItem(key) : 'true'
+);
 
 export function Video(props: IStoryComponentProps) {
   const { isPaused } = hooks.useStoriesContext();
   const [isMuted, setIsMuted] = useState(
-    WINDOW?.localStorage?.getItem(key) === 'true',
+    WINDOW?.localStorage?.getItem(key) === 'true'
   );
   const [showLoader, setShowLoader] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -35,7 +38,6 @@ export function Video(props: IStoryComponentProps) {
       return;
     }
     videoRef.current.play().catch(() => {
-      setMute(true);
       videoRef.current?.play();
     });
   }, [isPaused]);


### PR DESCRIPTION
This simple code change fixes an issue preventing the isMuted variable from being overridden causing the value to always be set to true when going from one story to another or when reloading the page. This might be unexpected to an user who is just trying to watch video stories in sequence without having to turn on the audio for every single story.

Solves Issue #41.